### PR TITLE
Fix workflow for stage-cap testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.1.0 - 2024-03-13
+## 1.0.1 - 2024-03-13
 - Makes non-optional workflow outputs. This update fixes the Vidarr error resulting from all outputs being optional.
 ## 1.0.0 - 2024-02-09
 - Alignment completed using Dragmap version 1.2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.1.0 - 2024-03-13
+- Makes non-optional workflow outputs. This update fixes the Vidarr error resulting from all outputs being optional.
 ## 1.0.0 - 2024-02-09
 - Alignment completed using Dragmap version 1.2.1
 - Includes the functionalities provided by the bwaMem workflow, version 2.2.1

--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ Parameter|Value|Default|Description
 
 Output | Type | Description
 ---|---|---
-`dragmapBam`|File?|Merged BAM file aligned to genome with Dragmap
-`dragmapIndex`|File?|Output index file for the merged BAM file
+`dragmapBam`|File|Merged BAM file aligned to genome with Dragmap
+`dragmapIndex`|File|Output index file for the merged BAM file
 `log`|File?|A summary log file for adapter trimming
 `cutAdaptAllLogs`|File?|A file with the logs from the adapter trimming of each fastq chunk
 


### PR DESCRIPTION
The dragmap olive was failing with:
`External IDs do not match
`
This occurred because all of dragmap's outputs are optional. There must be at least one non-optional output for the workflow – so the dragmap workflow was modified to account for this. I also removed the output of the readGroupCheck task, since it was not required.