### PR TITLE
Changed version of dragmap and samtools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.1.0 - 2024-03-19
+- Alignment completed using Dragmap version 1.3.1
+- Updated version of Samtools used to 1.14
 ## 1.0.1 - 2024-03-13
 - Makes non-optional workflow outputs. This update fixes the Vidarr error resulting from all outputs being optional.
 ## 1.0.0 - 2024-02-09

--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@ This workflow aligns sequence data provided as fastq files using Dragmap (an ope
 
 ## Dependencies
 
-* [dragmap 1.2.1](https://github.com/Illumina/DRAGMAP/archive/refs/tags/1.2.1.tar.gz)
-* [samtools 1.9](https://github.com/samtools/samtools/archive/0.1.19.tar.gz)
+* [dragmap 1.3.1](https://github.com/Illumina/DRAGMAP/tree/c4cb6c94baaf6821db3fa696c53cdd809fb92304)
+* [samtools 1.14](https://github.com/samtools/samtools/archive/refs/tags/1.14.tar.gz)
 * [picard 3.1.0](https://github.com/broadinstitute/picard/archive/refs/tags/3.1.0.tar.gz)
 * [cutadapt 1.8.3](https://cutadapt.readthedocs.io/en/v1.8.3/)
 * [slicer 0.3.0](https://github.com/OpenGene/slicer/archive/v0.3.0.tar.gz)
 * [python 3.7](https://www.python.org)
 * [barcodex-rs 0.1.2](https://github.com/oicr-gsi/barcodex-rs/archive/v0.1.2.tar.gz)
 * [rust 1.2](https://www.rust-lang.org/tools/install)
-* [gsi software modules: samtools 1.9 dragmap 1.2.1](https://gitlab.oicr.on.ca/ResearchIT/modulator)
+* [gsi software modules: samtools 1.14 dragmap 1.2.1](https://gitlab.oicr.on.ca/ResearchIT/modulator)
 * [gsi hg38 modules: dragmap-hash-table-hg38 p12](https://gitlab.oicr.on.ca/ResearchIT/modulator)
 * [gsi hg19 modules: dragmap-hash-table-hg19 p13](https://gitlab.oicr.on.ca/ResearchIT/modulator)
 * [gsi mm10 modules: dragmap-hash-table-mm10 p6](https://gitlab.oicr.on.ca/ResearchIT/modulator)
@@ -83,7 +83,7 @@ Parameter|Value|Default|Description
 `runDragmap.jobMemory`|Int|50|Memory allocated for the job
 `runDragmap.timeout`|Int|96|Hours until task timeout
 `bamMerge.jobMemory`|Int|32|Memory allocated for the job
-`bamMerge.modules`|String|"samtools/1.9"|Required environment modules
+`bamMerge.modules`|String|"samtools/1.14"|Required environment modules
 `bamMerge.timeout`|Int|72|Hours until task timeout
 `addReadGroups.modules`|String|"picard/3.1.0"|Required environment modules to run the task
 `addReadGroups.jobMemory`|Int|12|Memory allocated for the job

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This workflow aligns sequence data provided as fastq files using Dragmap (an ope
 * [python 3.7](https://www.python.org)
 * [barcodex-rs 0.1.2](https://github.com/oicr-gsi/barcodex-rs/archive/v0.1.2.tar.gz)
 * [rust 1.2](https://www.rust-lang.org/tools/install)
-* [gsi software modules: samtools 1.14 dragmap 1.2.1](https://gitlab.oicr.on.ca/ResearchIT/modulator)
+* [gsi software modules: samtools 1.14 dragmap 1.3.1](https://gitlab.oicr.on.ca/ResearchIT/modulator)
 * [gsi hg38 modules: dragmap-hash-table-hg38 p12](https://gitlab.oicr.on.ca/ResearchIT/modulator)
 * [gsi hg19 modules: dragmap-hash-table-hg19 p13](https://gitlab.oicr.on.ca/ResearchIT/modulator)
 * [gsi mm10 modules: dragmap-hash-table-mm10 p6](https://gitlab.oicr.on.ca/ResearchIT/modulator)

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This workflow aligns sequence data provided as fastq files using Dragmap (an ope
 ## Dependencies
 
 * [dragmap 1.3.1](https://github.com/Illumina/DRAGMAP/tree/c4cb6c94baaf6821db3fa696c53cdd809fb92304)
+* [boost 1.69](https://boostorg.jfrog.io/artifactory/main/release/1.69.0/source/boost_1_69_0.tar.gz)
 * [samtools 1.14](https://github.com/samtools/samtools/archive/refs/tags/1.14.tar.gz)
 * [picard 3.1.0](https://github.com/broadinstitute/picard/archive/refs/tags/3.1.0.tar.gz)
 * [cutadapt 1.8.3](https://cutadapt.readthedocs.io/en/v1.8.3/)
@@ -14,7 +15,7 @@ This workflow aligns sequence data provided as fastq files using Dragmap (an ope
 * [python 3.7](https://www.python.org)
 * [barcodex-rs 0.1.2](https://github.com/oicr-gsi/barcodex-rs/archive/v0.1.2.tar.gz)
 * [rust 1.2](https://www.rust-lang.org/tools/install)
-* [gsi software modules: samtools 1.14 dragmap 1.3.1](https://gitlab.oicr.on.ca/ResearchIT/modulator)
+* [gsi software modules: samtools 1.14 dragmap 1.3.1 boost 1.69](https://gitlab.oicr.on.ca/ResearchIT/modulator)
 * [gsi hg38 modules: dragmap-hash-table-hg38 p12](https://gitlab.oicr.on.ca/ResearchIT/modulator)
 * [gsi hg19 modules: dragmap-hash-table-hg19 p13](https://gitlab.oicr.on.ca/ResearchIT/modulator)
 * [gsi mm10 modules: dragmap-hash-table-mm10 p6](https://gitlab.oicr.on.ca/ResearchIT/modulator)

--- a/dragmap.wdl
+++ b/dragmap.wdl
@@ -34,15 +34,15 @@ workflow dragmap {
 
     Map[String,dragmapResources] resourceByGenome = { 
         "hg19": {
-            "modules": "samtools/1.14 dragmap/1.3.1 dragmap-hash-table-hg19/p13", 
+            "modules": "samtools/1.14 dragmap/1.3.1 boost/1.69 dragmap-hash-table-hg19/p13", 
             "hashTable": "$DRAGMAP_HASH_TABLE_HG19_ROOT/hg19"
         },
         "hg38": {
-            "modules": "samtools/1.14 dragmap/1.3.1 dragmap-hash-table-hg38/p12", 
+            "modules": "samtools/1.14 dragmap/1.3.1 boost/1.69 dragmap-hash-table-hg38/p12", 
             "hashTable": "$DRAGMAP_HASH_TABLE_HG38_ROOT/hg38"
         },
         "mm10": {
-            "modules": "samtools/1.14 dragmap/1.3.1 dragmap-hash-table-mm10/p6", 
+            "modules": "samtools/1.14 dragmap/1.3.1 boost/1.69 dragmap-hash-table-mm10/p6", 
             "hashTable": "$DRAGMAP_HASH_TABLE_MM10_ROOT/mm10"
         }
     }
@@ -151,6 +151,10 @@ workflow dragmap {
                 url: "https://github.com/Illumina/DRAGMAP/tree/c4cb6c94baaf6821db3fa696c53cdd809fb92304"
             },
             {
+                name: "boost/1.69",
+                url: "https://boostorg.jfrog.io/artifactory/main/release/1.69.0/source/boost_1_69_0.tar.gz"
+            },
+            {
                 name: "samtools/1.14",
                 url: "https://github.com/samtools/samtools/archive/refs/tags/1.14.tar.gz"
             },
@@ -179,7 +183,7 @@ workflow dragmap {
                 url: "https://www.rust-lang.org/tools/install"
             },
             { 
-                name: "gsi software modules: samtools/1.14 dragmap/1.3.1",
+                name: "gsi software modules: samtools/1.14 dragmap/1.3.1 boost/1.69",
                 url: "https://gitlab.oicr.on.ca/ResearchIT/modulator"
             },
             { 

--- a/dragmap.wdl
+++ b/dragmap.wdl
@@ -34,15 +34,15 @@ workflow dragmap {
 
     Map[String,dragmapResources] resourceByGenome = { 
         "hg19": {
-            "modules": "samtools/1.14 dragmap/1.3.1 dragmap-hash-table-hg19/p13", 
+            "modules": "samtools/1.14 dragmap-hash-table-hg19/p13", 
             "hashTable": "$DRAGMAP_HASH_TABLE_HG19_ROOT/hg19"
         },
         "hg38": {
-            "modules": "samtools/1.14 dragmap/1.3.1 dragmap-hash-table-hg38/p12", 
+            "modules": "samtools/1.14 dragmap-hash-table-hg38/p12", 
             "hashTable": "$DRAGMAP_HASH_TABLE_HG38_ROOT/hg38"
         },
         "mm10": {
-            "modules": "samtools/1.14 dragmap/1.3.1 dragmap-hash-table-mm10/p6", 
+            "modules": "samtools/1.14 dragmap-hash-table-mm10/p6", 
             "hashTable": "$DRAGMAP_HASH_TABLE_MM10_ROOT/mm10"
         }
     }
@@ -530,7 +530,7 @@ task runDragmap {
 
         export LD_LIBRARY_PATH=$BOOST_ROOT/lib 
 
-        dragen-os \
+        /.mounts/labs/gsiprojects/gsi/gsiusers/mmohamed/dragmap_test/NEW_dragmap/DRAGMAP/build/release/dragen-os \
             -r ~{dragmapHashTable} \
             -1 ~{read1s} \
             ~{if (defined(read2s)) then "-2 ~{read2s}" else ""} \

--- a/dragmap.wdl
+++ b/dragmap.wdl
@@ -34,15 +34,15 @@ workflow dragmap {
 
     Map[String,dragmapResources] resourceByGenome = { 
         "hg19": {
-            "modules": "samtools/1.14 boost/1.69 dragmap-hash-table-hg19/p13", 
+            "modules": "samtools/1.14 dragmap/1.3.1 dragmap-hash-table-hg19/p13", 
             "hashTable": "$DRAGMAP_HASH_TABLE_HG19_ROOT/hg19"
         },
         "hg38": {
-            "modules": "samtools/1.14 boost/1.69 dragmap-hash-table-hg38/p12", 
+            "modules": "samtools/1.14 dragmap/1.3.1 dragmap-hash-table-hg38/p12", 
             "hashTable": "$DRAGMAP_HASH_TABLE_HG38_ROOT/hg38"
         },
         "mm10": {
-            "modules": "samtools/1.14 boost/1.69 dragmap-hash-table-mm10/p6", 
+            "modules": "samtools/1.14 dragmap/1.3.1 dragmap-hash-table-mm10/p6", 
             "hashTable": "$DRAGMAP_HASH_TABLE_MM10_ROOT/mm10"
         }
     }
@@ -530,7 +530,7 @@ task runDragmap {
 
         export LD_LIBRARY_PATH=$BOOST_ROOT/lib 
 
-        /.mounts/labs/gsiprojects/gsi/gsiusers/mmohamed/dragmap_test/NEW_dragmap/DRAGMAP/build/release/dragen-os \
+        dragen-os \
             -r ~{dragmapHashTable} \
             -1 ~{read1s} \
             ~{if (defined(read2s)) then "-2 ~{read2s}" else ""} \

--- a/dragmap.wdl
+++ b/dragmap.wdl
@@ -34,15 +34,15 @@ workflow dragmap {
 
     Map[String,dragmapResources] resourceByGenome = { 
         "hg19": {
-            "modules": "samtools/1.14 dragmap-hash-table-hg19/p13", 
+            "modules": "samtools/1.14 boost/1.69 dragmap-hash-table-hg19/p13", 
             "hashTable": "$DRAGMAP_HASH_TABLE_HG19_ROOT/hg19"
         },
         "hg38": {
-            "modules": "samtools/1.14 dragmap-hash-table-hg38/p12", 
+            "modules": "samtools/1.14 boost/1.69 dragmap-hash-table-hg38/p12", 
             "hashTable": "$DRAGMAP_HASH_TABLE_HG38_ROOT/hg38"
         },
         "mm10": {
-            "modules": "samtools/1.14 dragmap-hash-table-mm10/p6", 
+            "modules": "samtools/1.14 boost/1.69 dragmap-hash-table-mm10/p6", 
             "hashTable": "$DRAGMAP_HASH_TABLE_MM10_ROOT/mm10"
         }
     }

--- a/dragmap.wdl
+++ b/dragmap.wdl
@@ -179,7 +179,7 @@ workflow dragmap {
                 url: "https://www.rust-lang.org/tools/install"
             },
             { 
-                name: "gsi software modules: samtools/1.14 dragmap/1.2.1",
+                name: "gsi software modules: samtools/1.14 dragmap/1.3.1",
                 url: "https://gitlab.oicr.on.ca/ResearchIT/modulator"
             },
             { 

--- a/dragmap.wdl
+++ b/dragmap.wdl
@@ -34,15 +34,15 @@ workflow dragmap {
 
     Map[String,dragmapResources] resourceByGenome = { 
         "hg19": {
-            "modules": "samtools/1.9 dragmap/1.2.1 dragmap-hash-table-hg19/p13", 
+            "modules": "samtools/1.14 dragmap/1.3.1 dragmap-hash-table-hg19/p13", 
             "hashTable": "$DRAGMAP_HASH_TABLE_HG19_ROOT/hg19"
         },
         "hg38": {
-            "modules": "samtools/1.9 dragmap/1.2.1 dragmap-hash-table-hg38/p12", 
+            "modules": "samtools/1.14 dragmap/1.3.1 dragmap-hash-table-hg38/p12", 
             "hashTable": "$DRAGMAP_HASH_TABLE_HG38_ROOT/hg38"
         },
         "mm10": {
-            "modules": "samtools/1.9 dragmap/1.2.1 dragmap-hash-table-mm10/p6", 
+            "modules": "samtools/1.14 dragmap/1.3.1 dragmap-hash-table-mm10/p6", 
             "hashTable": "$DRAGMAP_HASH_TABLE_MM10_ROOT/mm10"
         }
     }
@@ -147,12 +147,12 @@ workflow dragmap {
         description: "This workflow aligns sequence data provided as fastq files using Dragmap (an open source Dragen mapper/aligner). The alignment is completed using a hash table of a reference genome. The workflow borrows functions from the bwaMem workflow, to provide options to remove 5' umi sequences and trim off 3' sequencing adapters prior to alignment. Using these functions, this workflow can also split the input data into a requested number of chunks, align each separately then merge the separate alignments into a single BAM file to decrease workflow runtime. Read-group information must be provided."
         dependencies: [
             {
-                name: "dragmap/1.2.1",
-                url: "https://github.com/Illumina/DRAGMAP/archive/refs/tags/1.2.1.tar.gz"
+                name: "dragmap/1.3.1",
+                url: "https://github.com/Illumina/DRAGMAP/tree/c4cb6c94baaf6821db3fa696c53cdd809fb92304"
             },
             {
-                name: "samtools/1.9",
-                url: "https://github.com/samtools/samtools/archive/0.1.19.tar.gz"
+                name: "samtools/1.14",
+                url: "https://github.com/samtools/samtools/archive/refs/tags/1.14.tar.gz"
             },
             {
                 name: "picard/3.1.0",
@@ -179,7 +179,7 @@ workflow dragmap {
                 url: "https://www.rust-lang.org/tools/install"
             },
             { 
-                name: "gsi software modules: samtools/1.9 dragmap/1.2.1",
+                name: "gsi software modules: samtools/1.14 dragmap/1.2.1",
                 url: "https://gitlab.oicr.on.ca/ResearchIT/modulator"
             },
             { 
@@ -528,6 +528,8 @@ task runDragmap {
     command <<<
         set -euo pipefail
 
+        export LD_LIBRARY_PATH=$BOOST_ROOT/lib 
+
         dragen-os \
             -r ~{dragmapHashTable} \
             -1 ~{read1s} \
@@ -562,7 +564,7 @@ task bamMerge{
         Array[File] outputBams
         String outputFileNamePrefix
         Int jobMemory = 32
-        String modules = "samtools/1.9"
+        String modules = "samtools/1.14"
         Int timeout = 72
     }
 

--- a/vidarrtest-regression.json.in
+++ b/vidarrtest-regression.json.in
@@ -116,7 +116,7 @@
             {
                 "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
                 "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-                "output_metrics": "/.mounts/labs/gsi/testdata/dragmap/1.0.0/output_metrics/PCSI0022C_notrim_nosplit_bam.metrics",
+                "output_metrics": "/.mounts/labs/gsi/testdata/dragmap/1.1.0/output_metrics/PCSI0022C_notrim_nosplit_bam.metrics",
                 "type": "script"
             }
         ]
@@ -238,7 +238,7 @@
             {
                 "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
                 "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-                "output_metrics": "/.mounts/labs/gsi/testdata/dragmap/1.0.0/output_metrics/PCSI0022C_trim_nosplit_bam.metrics",
+                "output_metrics": "/.mounts/labs/gsi/testdata/dragmap/1.1.0/output_metrics/PCSI0022C_trim_nosplit_bam.metrics",
                 "type": "script"
             }
         ]
@@ -360,7 +360,7 @@
             {
                 "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
                 "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-                "output_metrics": "/.mounts/labs/gsi/testdata/dragmap/1.0.0/output_metrics/PCSI0022C_trim_split_hg19_bam.metrics",
+                "output_metrics": "/.mounts/labs/gsi/testdata/dragmap/1.1.0/output_metrics/PCSI0022C_trim_split_hg19_bam.metrics",
                 "type": "script"
             }
         ]
@@ -482,7 +482,7 @@
             {
                 "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
                 "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-                "output_metrics": "/.mounts/labs/gsi/testdata/dragmap/1.0.0/output_metrics/PCSI0022C_notrim_split_hg19_bam.metrics",
+                "output_metrics": "/.mounts/labs/gsi/testdata/dragmap/1.1.0/output_metrics/PCSI0022C_notrim_split_hg19_bam.metrics",
                 "type": "script"
             }
         ]
@@ -604,7 +604,7 @@
             {
                 "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
                 "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-                "output_metrics": "/.mounts/labs/gsi/testdata/dragmap/1.0.0/output_metrics/PCSI0022C_trim_split_hg38_bam.metrics",
+                "output_metrics": "/.mounts/labs/gsi/testdata/dragmap/1.1.0/output_metrics/PCSI0022C_trim_split_hg38_bam.metrics",
                 "type": "script"
             }
         ]
@@ -715,7 +715,7 @@
             {
                 "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
                 "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-                "output_metrics": "/.mounts/labs/gsi/testdata/dragmap/1.0.0/output_metrics/PCSI0022C_trim_split_hg19_bam_se.metrics",
+                "output_metrics": "/.mounts/labs/gsi/testdata/dragmap/1.1.0/output_metrics/PCSI0022C_trim_split_hg19_bam_se.metrics",
                 "type": "script"
             }
         ]
@@ -826,7 +826,7 @@
             {
                 "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
                 "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-                "output_metrics": "/.mounts/labs/gsi/testdata/dragmap/1.0.0/output_metrics/PCSI0022C_trim_nosplit_hg19_bam_se.metrics",
+                "output_metrics": "/.mounts/labs/gsi/testdata/dragmap/1.1.0/output_metrics/PCSI0022C_trim_nosplit_hg19_bam_se.metrics",
                 "type": "script"
             }
         ]
@@ -937,7 +937,7 @@
             {
                 "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
                 "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-                "output_metrics": "/.mounts/labs/gsi/testdata/dragmap/1.0.0/output_metrics/PCSI0022C_notrim_nosplit_hg19_bam_se.metrics",
+                "output_metrics": "/.mounts/labs/gsi/testdata/dragmap/1.1.0/output_metrics/PCSI0022C_notrim_nosplit_hg19_bam_se.metrics",
                 "type": "script"
             }
         ]
@@ -1059,7 +1059,7 @@
             {
                 "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
                 "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-                "output_metrics": "/.mounts/labs/gsi/testdata/dragmap/1.0.0/output_metrics/PCSI0022C_umi_adapter_trim_split_hg19_bam.metrics",
+                "output_metrics": "/.mounts/labs/gsi/testdata/dragmap/1.1.0/output_metrics/PCSI0022C_umi_adapter_trim_split_hg19_bam.metrics",
                 "type": "script"
             }
         ]
@@ -1181,7 +1181,7 @@
             {
                 "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
                 "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-                "output_metrics": "/.mounts/labs/gsi/testdata/dragmap/1.0.0/output_metrics/PCSI0022C_trim_split_hg38_numRead_bam.metrics",
+                "output_metrics": "/.mounts/labs/gsi/testdata/dragmap/1.1.0/output_metrics/PCSI0022C_trim_split_hg38_numRead_bam.metrics",
                 "type": "script"
             }
         ]
@@ -1303,7 +1303,7 @@
             {
                 "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
                 "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-                "output_metrics": "/.mounts/labs/gsi/testdata/dragmap/1.0.0/output_metrics/neat_5x_umi_extract_nosplit_hg19_bam.metrics",
+                "output_metrics": "/.mounts/labs/gsi/testdata/dragmap/1.1.0/output_metrics/neat_5x_umi_extract_nosplit_hg19_bam.metrics",
                 "type": "script"
             }
         ]


### PR DESCRIPTION
- Changed the version of dragmap to 1.3.1. Note that this version is a commit, not a release, but it may contain important bug fixes. 
- Updated the version of samtools since it was clashing with the dragmap modules. 
- The README, CHANGELOG, and RT files were updated as required.